### PR TITLE
Updates README to install plugin as a dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This extension provides instant Tailwind support to your Mix (v2.1 and up) build
 First, install the extension.
 
 ```
-npm install laravel-mix-tailwind
+npm install laravel-mix-tailwind --save-dev
 ```
 
 Then, require it within your `webpack.mix.js` file, like so:


### PR DESCRIPTION
This commit fixes the directions for installing laravel-mix-tailwind and advises users to install the plugin as a development dependency.